### PR TITLE
Feature/convert null to string

### DIFF
--- a/src/pokedex/dto/pokemon.dto.ts
+++ b/src/pokedex/dto/pokemon.dto.ts
@@ -97,16 +97,16 @@ export class PokemonDto {
 
   @Expose()
   @Transform(({ obj: { ability_1, ability_2, ability_hidden } }) => ({
-    ability_1: ability_1 ? ability_1.name : null,
-    ability_2: ability_2 ? ability_2.name : null,
-    ability_hidden: ability_hidden ? ability_hidden.name : null,
+    ability_1: ability_1 ? ability_1.name : '',
+    ability_2: ability_2 ? ability_2.name : '',
+    ability_hidden: ability_hidden ? ability_hidden.name : '',
   }))
   abilities: AbilityDto;
 
   @Expose()
   @Transform(({ obj: { type_1, type_2 } }) => ({
     type_1: type_1.element,
-    type_2: type_2 ? type_2.element : null,
+    type_2: type_2 ? type_2.element : '',
   }))
   types: TypesDto;
 

--- a/src/pokedex/dto/pokemon.dto.ts
+++ b/src/pokedex/dto/pokemon.dto.ts
@@ -105,7 +105,7 @@ export class PokemonDto {
 
   @Expose()
   @Transform(({ obj: { type_1, type_2 } }) => ({
-    type_1: type_1 ? type_1.element : null,
+    type_1: type_1.element,
     type_2: type_2 ? type_2.element : null,
   }))
   types: TypesDto;


### PR DESCRIPTION
MR related to: https://github.com/GSPanue/pokedex-api/issues/4

Response example with the changes:

```json
[
    {
        "id": 1,
        "name": "Bulbasaur",
        "german_name": "Bisasam",
        "japanese_name": "フシギダネ (Fushigidane)",
        "generation": 1,
        "rarity": "Normal",
        "species": "Seed",
        "abilities": {
            "ability_1": "Overgrow",
            "ability_2": "",
            "ability_hidden": "Chlorophyll"
        },
        "types": {
            "type_1": "Grass",
            "type_2": "Poison"
        },
        "height": {
            "value": 0.7,
            "unit": "metres"
        },
        "weight": {
            "value": 6.9,
            "unit": "kilograms"
        }
    }
]
```